### PR TITLE
Added option to hide orphan collections

### DIFF
--- a/CollectionTreePlugin.php
+++ b/CollectionTreePlugin.php
@@ -50,8 +50,9 @@ class CollectionTreePlugin extends Omeka_Plugin_AbstractPlugin
      */
     protected $_options = array(
         'collection_tree_alpha_order' => 0,
-        'collection_tree_browse_only_root' => 0,
         'collection_tree_show_subcollections' => 0,
+        'collection_tree_hide_orphans' => 0,
+        'collection_tree_browse_only_root' => 0,
         'collection_tree_search_descendant' => 0,
     );
 
@@ -357,10 +358,13 @@ class CollectionTreePlugin extends Omeka_Plugin_AbstractPlugin
     protected function _appendToCollectionsShow($collection)
     {
         $collectionTree = $this->_db->getTable('CollectionTree')->getCollectionTree($collection->id);
-        echo get_view()->partial(
-            'collections/collection-tree-list.php',
-            array('collection_tree' => $collectionTree)
-        );
+		
+		if (count($collectionTree[0]['children']) > 0 || !(bool)get_Option('collection_tree_hide_orphans')) {
+			echo get_view()->partial(
+				'collections/collection-tree-list.php',
+				array('collection_tree' => $collectionTree)
+			);
+		}
     }
 
     /**

--- a/views/admin/plugins/collection-tree-config-form.php
+++ b/views/admin/plugins/collection-tree-config-form.php
@@ -1,61 +1,82 @@
+<h2><?php echo __("Appearance"); ?></h2>
+
 <div class="field">
     <div class="two columns alpha">
         <?php echo $this->formLabel('collection_tree_alpha_order', __('Order alphabetically')); ?>
     </div>
     <div class="inputs five columns omega">
         <p class="explanation"><?php
-            echo __('Order the collection tree alphabetically?');
-            echo __('This does not affect the order of the collections browse page.');
+            echo __('If checked, the collection tree is ordered alphabetically (does not affect the order of the collections browse page).');
         ?></p>
         <?php echo $this->formCheckbox(
-            'collection_tree_alpha_order',
-            null,
+			'collection_tree_alpha_order', 
+			null,
             array('checked' => (bool) get_option('collection_tree_alpha_order'))
-        ); ?>
+		); ?>
     </div>
 </div>
-<div class="field">
-    <div class="two columns alpha">
-        <?php echo $this->formLabel('collection_tree_browse_only_root', __('Browse root-level collections only')); ?>
-    </div>
-    <div class="inputs five columns omega">
-        <p class="explanation"><?php
-            echo __('Limit the public collections browse page to root-level collections.');
-        ?></p>
-        <?php echo $this->formCheckbox(
-            'collection_tree_browse_only_root',
-            null,
-            array('checked' => (bool) get_option('collection_tree_browse_only_root'))
-        ); ?>
-    </div>
-</div>
+
 <div class="field">
     <div class="two columns alpha">
         <?php echo $this->formLabel('collection_tree_show_subcollections', __('Show subcollection items')); ?>
     </div>
     <div class="inputs five columns omega">
         <p class="explanation"><?php
-            echo __('On public collection show pages, display items belonging to all subcollections. This is especially useful when root collections are empty and used as main categories.');
+            echo __('If checked, on public collection show pages displays items belonging to all subcollections (especially useful when root collections are empty and used as main categories).');
         ?></p>
         <?php echo $this->formCheckbox(
-            'collection_tree_show_subcollections',
-            null,
+			'collection_tree_show_subcollections', 
+			null,
             array('checked' => (bool) get_option('collection_tree_show_subcollections'))
-        ); ?>
+		); ?>
     </div>
 </div>
+
+<div class="field">
+    <div class="two columns alpha">
+        <?php echo $this->formLabel('collection_tree_hide_orphans', __('Hide orphan collections')); ?>
+    </div>
+    <div class="inputs five columns omega">
+        <p class="explanation"><?php
+            echo __('If checked, no collection tree will be shown for collections without parent nor children.');
+        ?></p>
+        <?php echo $this->formCheckbox(
+			'collection_tree_hide_orphans', 
+			null,
+            array('checked' => (bool) get_option('collection_tree_hide_orphans'))
+		); ?>
+    </div>
+</div>
+
+<h2><?php echo __("Browsing & Searching"); ?></h2>
+<div class="field">
+    <div class="two columns alpha">
+        <?php echo $this->formLabel('collection_tree_browse_only_root', __('Browse root-level collections only')); ?>
+    </div>
+    <div class="inputs five columns omega">
+        <p class="explanation"><?php
+            echo __('If checked, limits the public collections browse page to root-level collections.');
+        ?></p>
+        <?php echo $this->formCheckbox(
+			'collection_tree_browse_only_root', 
+			null,
+            array('checked' => (bool) get_option('collection_tree_browse_only_root'))
+		); ?>
+    </div>
+</div>
+
 <div class="field">
     <div class="two columns alpha">
         <?php echo $this->formLabel('collection_tree_search_descendant', __('Expand search to subcollection items by default')); ?>
     </div>
     <div class="inputs five columns omega">
         <p class="explanation"><?php
-            echo __('When searching by collection, expand searching to all subcollections by default.');
+            echo __('If checked, expands searching to all subcollections by default when searching by Collection.');
         ?></p>
         <?php echo $this->formCheckbox(
-            'collection_tree_search_descendant',
-            null,
+			'collection_tree_search_descendant', 
+			null,
             array('checked' => (bool) get_option('collection_tree_search_descendant'))
-        ); ?>
+		); ?>
     </div>
 </div>


### PR DESCRIPTION
A collection tree for collections that have neither parent nor children is not particularly useful, so let's keep it clean.